### PR TITLE
Fix Table header with hidden fields

### DIFF
--- a/src/Forms/Components/TableRepeater.php
+++ b/src/Forms/Components/TableRepeater.php
@@ -23,7 +23,9 @@ class TableRepeater extends Repeater
         $components = $this->getChildComponents();
 
         foreach ($components as $component) {
-            $this->columnLabels[] = $component->getLabel();
+            if(!$component->isHidden() && !($component instanceof \Filament\Forms\Components\Hidden)) {
+                $this->columnLabels[] = $component->getLabel();
+            }
         }
     }
 


### PR DESCRIPTION
Hidden fields label are shown in table's header. This fixed the issue #5 