### PR TITLE
Cleanup the design

### DIFF
--- a/resources/views/table-repeater.blade.php
+++ b/resources/views/table-repeater.blade.php
@@ -67,7 +67,7 @@
             @endif
         </div>
 
-        <div class="px-4">
+        <div class="p-4">
             <table class="w-full text-left rtl:text-right table-auto mx-4 filament-table-repeater" x-show="! isCollapsed">
                 <thead>
                     <tr>
@@ -106,7 +106,7 @@
                         >
 
                             @foreach($item->getComponents() as $component)
-                            <td
+                            <td class="px-2 py-1" 
                                 @if($component->isHidden() || ($component instanceof \Filament\Forms\Components\Hidden))style="display:none"@endif
                             >
                                 {{ $component }}
@@ -114,7 +114,7 @@
                             @endforeach
 
 							@if (!$isItemMovementDisabled || !$isItemDeletionDisabled)
-								<td class="w-10 flex">
+								<td class="w-10 flex py-1">
 									@if (!$isItemMovementDisabled)
 										<button
 											wire:sortable.handle


### PR DESCRIPTION
* Changing the  `px-4`-> `p-4` gives the table the same padding vertically as horizontally, alternatively the table runs right into the bottom border.
* The second and third change of adding the padding to the `<td>` aligns it horizontally with the padding of the `th` plus gives it a bit of vertical breathing room.