### PR TITLE
change dependency with filaments/forms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "filament/filament":"^2.0",
+        "filament/forms":"^2.0",
         "spatie/laravel-package-tools": "^1.9.2",
         "illuminate/contracts": "^8.6|^9.0"
     },


### PR DESCRIPTION
Hello,
In case you want to use filament form in this standalone version, i.e. without the admin panel, then it still includes the whole admin panel.

I replaced the dependency in composer
I tested via the admin panel and in stand-alone mode everything works.

Thanks