### PR TITLE
Initialize the $colStyles property to null in the TableRepeater class

### DIFF
--- a/src/Forms/Components/TableRepeater.php
+++ b/src/Forms/Components/TableRepeater.php
@@ -11,7 +11,7 @@ class TableRepeater extends Repeater
     //columns for table header
     protected array|null $columnLabels = [];
 
-    protected array|null $colStyles;
+    protected array|null $colStyles = null;
 
     public function getColumnLabels(): array|null
     {


### PR DESCRIPTION
This pull request fixes a runtime error in the TableRepeater class where the $colStyles property was not initialized before it was accessed, resulting in the error message "Typed property Icetalker\FilamentTableRepeater\Forms\Components\TableRepeater::$colStyles must not be accessed before initialization".

To fix this error, the $colStyles property is initialized to null when declaring it in the TableRepeater class. This ensures that the property is initialized before it is accessed, preventing any potential runtime errors.

Please review and merge this pull request at your earliest convenience.