### PR TITLE
no action if reorderable is disabled

### DIFF
--- a/resources/views/table-repeater.blade.php
+++ b/resources/views/table-repeater.blade.php
@@ -17,6 +17,7 @@
         $isCloneable = $isCloneable();
         $isCollapsible = $isCollapsible();
         $isDeletable = $isDeletable();
+        $isReorderable = $isReorderable();
         $isReorderableWithButtons = $isReorderableWithButtons();
         $isReorderableWithDragAndDrop = $isReorderableWithDragAndDrop();
 
@@ -101,8 +102,10 @@
                 </thead>
 
                 <tbody
-                    :wire:end.stop="'mountFormComponentAction(\'' . $statePath . '\', \'reorder\', { items: $event.target.sortable.toArray() })'"
-                    x-sortable
+                    @if($isReorderable)
+                        :wire:end.stop="'mountFormComponentAction(\'' . $statePath . '\', \'reorder\', { items: $event.target.sortable.toArray() })'"
+                       x-sortable
+                    @endif
                 >
 
                     @foreach ($containers as $uuid => $item)


### PR DESCRIPTION
Hey,

nice plugin by the way.

I have one litte issue. If is disable reorderable I get this error.

livewire.min.js?id=d02a3788:1 Alpine Expression Error: Unexpected string

Expression: "$wire.'mountFormComponentAction(\'' . $statePath . '\', \'reorder\', { items: $event.target.sortable.toArray() })'"

So I surrounded the action with a reorderable check. 