### PR TITLE
Add align-top class to cell items to prevent vertical misalign

### DIFF
--- a/resources/views/table-repeater.blade.php
+++ b/resources/views/table-repeater.blade.php
@@ -119,7 +119,7 @@
 
                             @foreach($item->getComponents() as $component)
                             <td
-                                class="filament-table-repeater-tbody-cell px-1"
+                                class="filament-table-repeater-tbody-cell px-1 align-top"
                                 @if($component->isHidden() || ($component instanceof \Filament\Forms\Components\Hidden))style="display:none"@endif
                                 @if($colStyles && isset($colStyles[$component->getName()]))
                                     style="$colStyles[$component->getName()]"


### PR DESCRIPTION
When using `helperText()` on a form component, the cells appear misaligned:

<img width="1246" alt="filament-table-repeater-misaligned" src="https://github.com/icetalker/filament-table-repeater/assets/761443/cc724480-5ecc-4011-989e-c08eb140e65d">

I've added tailwind's `align-top` class to the cells to prevent this:

<img width="1234" alt="filament-table-repeater-aligned" src="https://github.com/icetalker/filament-table-repeater/assets/761443/8e860622-81a4-42bc-9925-19ff9b470f36">

